### PR TITLE
feat : 2주차 DFS, 3주차 BFS solved

### DIFF
--- a/sangyeop/src/week2/Baekjoon1012.java
+++ b/sangyeop/src/week2/Baekjoon1012.java
@@ -1,0 +1,71 @@
+package week2;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Baekjoon1012 {
+    private static int M;
+    private static int N;
+    private static int K;
+
+    private static int[] directionX = {0, -1, 0, 1};
+    private static int[] directionY = {1, 0, -1, 0};
+    private static int[][] map;
+
+    private static boolean[][] isVisits;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < T; i++) {
+            int result = 0;
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            M = Integer.parseInt(st.nextToken());
+            N = Integer.parseInt(st.nextToken());
+            K = Integer.parseInt(st.nextToken());
+
+            map = new int[M][N];
+            isVisits = new boolean[M][N];
+
+            for (int j = 0; j < K; j++) {
+                st = new StringTokenizer(br.readLine());
+                int row = Integer.parseInt(st.nextToken());
+                int column = Integer.parseInt(st.nextToken());
+                map[row][column] = 1;
+            }
+
+
+            for (int j = 0; j < M; j++) {
+                for (int k = 0; k < N; k++) {
+                    if (map[j][k] == 1 && !isVisits[j][k]) {
+                        dfs(j, k);
+                        result++;
+                    }
+                }
+            }
+            sb.append(result)
+              .append("\n");
+        }
+
+        System.out.println(sb);
+
+    }
+
+    private static void dfs(int x, int y) {
+        isVisits[x][y] = true;
+
+        for (int i = 0; i < 4; i++) {
+            int moveX = x + directionX[i];
+            int moveY = y + directionY[i];
+
+            if (moveX >= 0 && moveY >= 0 && moveX < M && moveY < N) {
+                if (!isVisits[moveX][moveY] && map[moveX][moveY] == 1) {
+                    dfs(moveX, moveY);
+                }
+            }
+        }
+    }
+}

--- a/sangyeop/src/week2/Baekjoon11724.java
+++ b/sangyeop/src/week2/Baekjoon11724.java
@@ -1,0 +1,53 @@
+package week2;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Baekjoon11724 {
+    private static int result;
+    private static boolean[][] components;
+    private static boolean[] isVisits;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        components = new boolean[N+1][N+1];
+        isVisits = new boolean[N+1];
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+
+            components[from][to] = true;
+            components[to][from] = true;
+        }
+
+        for (int i = 1; i < components.length; i++) {
+            if (!isVisits[i]) {
+                result++;
+                dfs(i);
+            }
+        }
+        System.out.println(result);
+    }
+
+    private static void dfs(int start) {
+        isVisits[start] = true;
+
+        for (int i = 1; i < components.length; i++) {
+            if (components[start][i] && !isVisits[i]) {
+                dfs(i);
+            }
+        }
+    }
+
+}

--- a/sangyeop/src/week2/Baekjoon2309.java
+++ b/sangyeop/src/week2/Baekjoon2309.java
@@ -1,0 +1,63 @@
+package week2;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Baekjoon2309 {
+
+    private static StringBuilder sb = new StringBuilder();
+    private static int heights[];
+
+    private static List<Integer> results = new ArrayList();
+
+    private static boolean[] isVisits;
+    private static boolean isPrinted;
+
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        heights = new int[9];
+        isVisits = new boolean[9];
+
+        for (int i = 0; i < 9; i++) {
+            heights[i] = Integer.parseInt(br.readLine());
+        }
+
+        dfs(0);
+        System.out.println(sb);
+
+    }
+
+    private static void dfs(int at) {
+        if (results.size() == 7 && !isPrinted) {
+            int sum = 0;
+            for (int result : results) {
+                sum += result;
+            }
+
+            if (sum == 100) {
+                Collections.sort(results);
+                for (int result : results) {
+                    sb.append(result)
+                      .append("\n");
+                }
+                isPrinted = true;
+                return;
+            }
+        }
+
+        for (int i = at; i < 9; i++) {
+            if (!isVisits[i]) {
+                isVisits[i] = true;
+                results.add(heights[i]);
+                dfs(i);
+                isVisits[i] = false;
+                results.remove(results.size() - 1);
+            }
+        }
+    }
+}

--- a/sangyeop/src/week2/Baekjoon2606.java
+++ b/sangyeop/src/week2/Baekjoon2606.java
@@ -1,0 +1,44 @@
+package week2;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Baekjoon2606 {
+    private static boolean[] isVisits;
+    private static boolean[][] virus;
+    private static int result;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int computer = Integer.parseInt(br.readLine());
+        int pair = Integer.parseInt(br.readLine());
+
+
+        isVisits = new boolean[computer+1];
+        virus = new boolean[computer+1][computer+1];
+
+        for (int i = 0; i < pair; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+
+            virus[from][to] = true;
+            virus[to][from] = true;
+        }
+
+        dfs(1);
+        System.out.println(result);
+    }
+
+    private static void dfs(int from) {
+        isVisits[from] = true;
+
+        for (int i = 1; i < virus.length; i++) {
+            if (virus[from][i] && !isVisits[i]) {
+                result++;
+                dfs(i);
+            }
+        }
+    }
+}

--- a/sangyeop/src/week2/Baekjoon2667.java
+++ b/sangyeop/src/week2/Baekjoon2667.java
@@ -1,0 +1,74 @@
+package week2;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class Baekjoon2667 {
+    private static int houses[][];
+    private static boolean isVisits[][];
+
+    private static int N;
+    private static int[] directionX = {0, -1, 0, 1};
+    private static int[] directionY = {-1, 0, 1, 0};
+
+    private static int count = 0;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+
+        List<Integer> counts = new ArrayList<>();
+
+        houses = new int[N][N];
+        isVisits = new boolean[N][N];
+
+        for (int i = 0; i < N; i++) {
+            String[] split = br.readLine()
+                               .split("");
+            for (int j = 0; j < N; j++) {
+                houses[i][j] = Integer.parseInt(split[j]);
+            }
+        }
+
+        int result = 0;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (!isVisits[i][j] && houses[i][j] == 1) {
+                    count = 1;
+                    dfs(i, j);
+                    result++;
+                    counts.add(count);
+                }
+            }
+        }
+        System.out.println(result);
+        Collections.sort(counts);
+        for (Integer integer : counts) {
+            sb.append(integer)
+              .append("\n");
+        }
+        System.out.println(sb);
+
+    }
+
+    private static void dfs(int x, int y) {
+        isVisits[x][y] = true;
+
+        for (int i = 0; i < 4; i++) {
+            int moveX = x + directionX[i];
+            int moveY = y + directionY[i];
+
+            if (moveX >= 0 && moveY >= 0 && moveX < N && moveY < N) {
+                if (!isVisits[moveX][moveY] && houses[moveX][moveY] == 1) {
+                    count++;
+                    dfs(moveX, moveY);
+                }
+            }
+        }
+    }
+}

--- a/sangyeop/src/week2/Baekjoon2798.java
+++ b/sangyeop/src/week2/Baekjoon2798.java
@@ -1,0 +1,64 @@
+package week2;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Baekjoon2798 {
+    private static StringBuilder sb = new StringBuilder();
+    private static int N;
+    private static int M;
+
+    private static int[] cards;
+    private static boolean[] isVisits;
+    private static List<Integer> results = new ArrayList<>();
+
+    private static int max;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        cards = new int[N];
+        isVisits = new boolean[N];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            cards[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dfs(0);
+        System.out.println(max);
+    }
+    private static void dfs(int at) {
+        if (results.size() == 3) {
+            int sum = 0;
+            for (int result : results) {
+                sum += result;
+            }
+
+            if (sum <= M) {
+                if (max < sum) {
+                    max = sum;
+                }
+            }
+            return;
+        }
+
+        for (int i = at; i < N; i++) {
+            if (!isVisits[i]) {
+                isVisits[i] = true;
+                results.add(cards[i]);
+                dfs(i);
+                isVisits[i] = false;
+                results.remove(results.size() - 1);
+            }
+        }
+
+    }
+}

--- a/sangyeop/src/week3/Baekjoon1012BFS.java
+++ b/sangyeop/src/week3/Baekjoon1012BFS.java
@@ -1,0 +1,73 @@
+package week3;
+
+import org.w3c.dom.Attr;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Baekjoon1012BFS {
+    static int[][] cabbages;
+    static boolean[][] isVisits;
+
+    static int M;
+    static int N;
+    static int[] dx = {0, -1, 0, 1};
+    static int[] dy = {-1, 0, 1, 0};
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < T; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            M = Integer.parseInt(st.nextToken());
+            N = Integer.parseInt(st.nextToken());
+            int K = Integer.parseInt(st.nextToken());
+
+            cabbages = new int[M][N];
+            isVisits = new boolean[M][N];
+
+            for (int j = 0; j < K; j++) {
+                st = new StringTokenizer(br.readLine());
+                int x = Integer.parseInt(st.nextToken());
+                int y = Integer.parseInt(st.nextToken());
+                cabbages[x][y] = 1;
+            }
+
+            int result = 0;
+
+            for (int j = 0; j < M; j++) {
+                for (int k = 0; k < N; k++) {
+                    if (cabbages[j][k] == 1 && !isVisits[j][k]) {
+                        result++;
+                        bfs(j, k);
+                    }
+                }
+            }
+            System.out.println(result);
+
+        }
+    }
+
+    private static void bfs(int x, int y) {
+        Queue<int[]> queue = new LinkedList<>();
+        queue.offer(new int[]{x, y});
+        isVisits[x][y] = true;
+
+        while (!queue.isEmpty()) {
+            int[] poll = queue.poll();
+            for (int i = 0; i < 4; i++) {
+                int moveX = poll[0] + dx[i];
+                int moveY = poll[1] + dy[i];
+
+                if (moveX >= 0 && moveX < M && moveY >= 0 && moveY < N && cabbages[moveX][moveY] == 1 && !isVisits[moveX][moveY]) {
+                    queue.offer(new int[]{moveX, moveY});
+                    isVisits[moveX][moveY] = true;
+                }
+            }
+        }
+    }
+}

--- a/sangyeop/src/week3/Baekjoon11724BFS.java
+++ b/sangyeop/src/week3/Baekjoon11724BFS.java
@@ -1,0 +1,59 @@
+package week3;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Baekjoon11724BFS {
+    static boolean[][] components;
+    static boolean[] visits;
+    static int N;
+    static int M;
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        components = new boolean[N + 1][N + 1];
+        visits = new boolean[N + 1];
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int first = Integer.parseInt(st.nextToken());
+            int second = Integer.parseInt(st.nextToken());
+
+            components[first][second] = true;
+            components[second][first] = true;
+        }
+
+        int count = 0;
+
+        for (int i = 1; i <= N; i++) {
+            if (!visits[i]) {
+                count++;
+                bfs(i);
+            }
+        }
+
+        System.out.println(count);
+    }
+    static void bfs(int start) {
+        Queue<Integer> queue = new LinkedList<>();
+        queue.offer(start);
+        visits[start] = true;
+
+        while (!queue.isEmpty()) {
+            Integer poll = queue.poll();
+            for (int i = 1; i <= N; i++) {
+                if ((components[poll][i] || components[i][poll]) && !visits[i]) {
+                    queue.offer(i);
+                    visits[i] = true;
+                }
+            }
+        }
+    }
+}

--- a/sangyeop/src/week3/Baekjoon2309BFS.java
+++ b/sangyeop/src/week3/Baekjoon2309BFS.java
@@ -1,0 +1,39 @@
+package week3;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Baekjoon2309BFS {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        List<Integer> heights = new ArrayList<>();
+
+        int sum = 0;
+        for (int i = 0; i < 9; i++) {
+            heights.add(Integer.parseInt(br.readLine()));
+            sum += heights.get(i);
+        }
+
+        Collections.sort(heights);
+
+        int noAnswer1 = 0;
+        int noAnswer2 = 0;
+
+        for (int i = 0; i < 8; i++) {
+            for (int j = i + 1; j < 9; j++) {
+                if (sum - heights.get(i) - heights.get(j) == 100) {
+                    noAnswer1 = heights.get(i);
+                    noAnswer2 = heights.get(j);
+                }
+            }
+        }
+
+        for (Integer height : heights) {
+            if (height != noAnswer1 && height != noAnswer2) {
+                System.out.println(height);
+            }
+        }
+    }
+}

--- a/sangyeop/src/week3/Baekjoon2606BFS.java
+++ b/sangyeop/src/week3/Baekjoon2606BFS.java
@@ -1,0 +1,54 @@
+package week3;
+
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Baekjoon2606BFS {
+    static int computer;
+    static int pair;
+    static boolean[][] pairs;
+    static boolean[] visits;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        computer = Integer.parseInt(br.readLine());
+        pair = Integer.parseInt(br.readLine());
+
+        pairs = new boolean[computer+1][computer+1];
+        visits = new boolean[computer+1];
+
+        for (int i = 0; i < pair; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int first = Integer.parseInt(st.nextToken());
+            int second = Integer.parseInt(st.nextToken());
+
+            pairs[first][second] = true;
+            pairs[second][first] = true;
+        }
+
+        bfs(1);
+    }
+
+    static void bfs(int start) {
+        Queue<Integer> queue = new LinkedList<>();
+        queue.offer(start);
+        visits[start] = true;
+
+        int count = 0;
+
+        while (!queue.isEmpty()) {
+            Integer poll = queue.poll();
+
+            for (int i = 1; i <= computer; i++) {
+                if ((pairs[poll][i] || pairs[i][poll]) && !visits[i]) {
+                    queue.offer(i);
+                    visits[i] = true;
+                    count++;
+                }
+            }
+        }
+        System.out.println(count);
+    }
+}

--- a/sangyeop/src/week3/Baekjoon2667BFS.java
+++ b/sangyeop/src/week3/Baekjoon2667BFS.java
@@ -1,0 +1,70 @@
+package week3;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Baekjoon2667BFS {
+    static int[][] map;
+    static boolean[][] visits;
+    static int[] dx = {-1, 0, 1, 0};
+    static int[] dy = {0, -1, 0, 1};
+
+    static int N;
+    static StringBuilder sb = new StringBuilder();
+    static List<Integer> counts = new ArrayList<>();
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+
+        map = new int[N][N];
+        visits = new boolean[N][N];
+
+        int totalHouse = 0;
+
+        for (int i = 0; i < N; i++) {
+            String[] split = br.readLine()
+                               .split("");
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(split[j]);
+            }
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (map[i][j] == 1 && !visits[i][j]) {
+                    totalHouse++;
+                    bfs(i, j);
+                }
+            }
+        }
+        System.out.println(totalHouse);
+        Collections.sort(counts);
+        for (Integer count : counts) {
+            sb.append(count)
+              .append("\n");
+        }
+        System.out.println(sb);
+    }
+    static void bfs(int x, int y) {
+        Queue<int[]> queue = new LinkedList<>();
+        queue.offer(new int[]{x, y});
+        visits[x][y] = true;
+
+        int count = 1;
+        while (!queue.isEmpty()) {
+            int[] poll = queue.poll();
+            for (int i = 0; i < 4; i++) {
+                int moveX = poll[0] + dx[i];
+                int moveY = poll[1] + dy[i];
+                if (moveX >= 0 && moveX < N && moveY >= 0 && moveY < N && map[moveX][moveY] == 1 && !visits[moveX][moveY]) {
+                    queue.offer(new int[]{moveX, moveY});
+                    visits[moveX][moveY] = true;
+                    count++;
+                }
+            }
+        }
+        counts.add(count);
+    }
+}

--- a/sangyeop/src/week3/Baekjoon2798BFS.java
+++ b/sangyeop/src/week3/Baekjoon2798BFS.java
@@ -1,0 +1,40 @@
+package week3;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Baekjoon2798BFS {
+    static int N;
+    static int M;
+    static int[] cards;
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        cards = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            cards[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int result = 0;
+        int sum = 0;
+
+        for (int i = 0; i < N; i++) {
+            for (int j = i+1; j < N; j++) {
+                for (int k = j+1; k < N; k++) {
+                    sum = cards[i] + cards[j] + cards[k];
+                    if (sum <= M && result < sum) {
+                        result = sum;
+                    }
+                }
+            }
+        }
+        System.out.println(result);
+
+    }
+}


### PR DESCRIPTION
### DFS
- [x] [일곱난쟁이](https://www.acmicpc.net/problem/2309) 
- [x] [블랙잭](https://www.acmicpc.net/problem/2798)
- [x] [유기농 배추](https://www.acmicpc.net/problem/1012)
- [x] [단지번호붙이기](https://www.acmicpc.net/problem/2667)   
- [x] [바이러스](https://www.acmicpc.net/problem/2606)
- [x] [연결 요소의 개수](https://www.acmicpc.net/problem/11724)

유기농 배추 문제에서 풀이가 막혀, 문제 솔루션을 참고했습니다. 이후 문제들은 해당 솔루션을 응용하여 풀이할 수 있었습니다  

### BFS
일곱난쟁이와 블랙잭문제와 같은 단순 리스트 탐색 문제에 BFS를 적용시키는 방법이 아직 와 닿지 않는것 같습니다..
